### PR TITLE
Improve multigraph support and other changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 *.pyc
+*.egg-info
+build
+dist

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: python
+python:
+  - 2.6
+  - 2.7
+script:
+  - python setup.py test

--- a/munin/client.py
+++ b/munin/client.py
@@ -34,6 +34,9 @@ class Client(object):
         self._connection = socket.create_connection((self.host, self.port))
         self.hello_string = self._readline()
 
+        self._connection.sendall("cap multigraph\n")
+        self.cap_list = self._readline().split()[1:]
+
     def list(self):
         self._connection.sendall("list\n")
         return self._readline().split(' ')

--- a/munin/client.py
+++ b/munin/client.py
@@ -85,16 +85,20 @@ class Client(object):
     def config(self, key):
         self._connection.sendall("config %s\n" % key)
         ret = {}
+        data = ret
         for line in self._iterline():
-            if line.startswith('graph_'):
+            if line.startswith("multigraph "):
+                subkey = line.split()[1]
+                ret[subkey] = data = {}
+            elif line.startswith('graph_'):
                 key, value = line.split(' ', 1)
-                ret[key] = value
+                data[key] = value
             else:
                 key, rest = line.split('.', 1)
                 prop, value = rest.split(' ', 1)
-                if not ret.get(key):
-                    ret[key] = {}
-                ret[key][prop] = value
+                if key not in data:
+                    data[key] = {}
+                data[key][prop] = value
         return ret
 
     def nodes(self):

--- a/setup.py
+++ b/setup.py
@@ -36,4 +36,5 @@ setuptools.setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python"
     ],
+    test_suite="test",
 )

--- a/test.py
+++ b/test.py
@@ -2,10 +2,32 @@ import unittest
 
 import SocketServer
 import threading
-from munin.client import Client, ClientError
+from munin.client import Client, ClientError, _itergraph
 
 class MockServer(SocketServer.TCPServer):
     allow_reuse_address = True
+
+class TestIterGraph(unittest.TestCase):
+    def test_none(self):
+
+        inp = ["1", "2"]
+
+        for graph, lines in _itergraph("foo", inp):
+            self.assertEqual(graph, "foo")
+            self.assertEqual(["1", "2"], list(lines))
+
+    def test_two(self):
+
+        inp = ["multigraph foo_1", "1", "2", "multigraph foo_2", "3", "4"]
+
+        for graph, lines in _itergraph("foo", inp):
+
+            if graph == "foo_1":
+                self.assertEqual(["1", "2"], list(lines))
+            elif graph == "foo_2":
+                self.assertEqual(["3", "4"], list(lines))
+            else:
+                self.fail()
 
 class TestClient(unittest.TestCase):
     def setUp(self):
@@ -53,6 +75,67 @@ class TestClient(unittest.TestCase):
         c.connect()
 
         self.assertEqual(c.list(), ['foo', 'bar'])
+
+    def test_fetch_multigraph(self):
+        class MockFetchHandler(SocketServer.BaseRequestHandler):
+            def handle(self):
+                f = self.request.makefile()
+
+                self.request.sendall("mock\n")
+                f.readline()
+                self.request.sendall("cap multigraph\n")
+                f.readline()
+                self.request.sendall("multigraph foo_1\n")
+                self.request.sendall("x.value 1\n")
+                self.request.sendall("multigraph foo_2\n")
+                self.request.sendall("y.value 2\n")
+                self.request.sendall(".\n")
+
+        self._mock(MockFetchHandler)
+
+        c = Client('localhost', port=9998)
+        c.connect()
+
+        self.assertEqual(c.fetch("foo"), {'foo_1': {'x': 1.0}, 'foo_2': {'y': 2.0}})
+
+    def test_fetch(self):
+        class MockFetchHandler(SocketServer.BaseRequestHandler):
+            def handle(self):
+                f = self.request.makefile()
+
+                self.request.sendall("mock\n")
+                f.readline()
+                self.request.sendall("cap multigraph\n")
+                f.readline()
+                self.request.sendall("x.value 1\n")
+                self.request.sendall(".\n")
+
+        self._mock(MockFetchHandler)
+
+        c = Client('localhost', port=9998)
+        c.connect()
+
+        self.assertEqual(c.fetch("foo"), {'foo': {'x': 1.0}})
+
+    def test_config(self):
+        class MockConfigHandler(SocketServer.BaseRequestHandler):
+            def handle(self):
+                f = self.request.makefile()
+
+                self.request.sendall("mock\n")
+                f.readline()
+                self.request.sendall("cap multigraph\n")
+                f.readline()
+                self.request.sendall("graph_info foo\n")
+                self.request.sendall("x.info bar\n")
+                self.request.sendall(".\n")
+
+        self._mock(MockConfigHandler)
+
+        c = Client('localhost', port=9998)
+        c.connect()
+
+        self.assertEqual(c.config("foo"), {'foo': {'graph_info': 'foo', 'x': {'info': 'bar'}}})
 
 if __name__ == "__main__":
     unittest.main()

--- a/test.py
+++ b/test.py
@@ -36,5 +36,23 @@ class TestClient(unittest.TestCase):
         with self.assertRaises(ClientError):
             c.connect()
 
+    def test_list(self):
+        class MockListHandler(SocketServer.BaseRequestHandler):
+            def handle(self):
+                f = self.request.makefile()
+
+                self.request.sendall("mock\n")
+                f.readline()
+                self.request.sendall("cap multigraph\n")
+                f.readline()
+                self.request.sendall("foo bar\n")
+
+        self._mock(MockListHandler)
+
+        c = Client('localhost', port=9998)
+        c.connect()
+
+        self.assertEqual(c.list(), ['foo', 'bar'])
+
 if __name__ == "__main__":
     unittest.main()

--- a/test.py
+++ b/test.py
@@ -1,0 +1,40 @@
+import unittest
+
+import SocketServer
+import threading
+from munin.client import Client, ClientError
+
+class MockServer(SocketServer.TCPServer):
+    allow_reuse_address = True
+
+class TestClient(unittest.TestCase):
+    def setUp(self):
+        self.s = None
+
+    def tearDown(self):
+        if self.s is not None:
+            self.s.shutdown()
+            self.s.server_close()
+            self.t.join()
+
+    def _mock(self, handler):
+        self.s = MockServer(("localhost", 9998), handler)
+        self.t = threading.Thread(target=self.s.serve_forever)
+        self.t.start()
+
+    def test_denied(self):
+        # Munin node just closes connection if source address is not
+        # allowed access.
+
+        class MockDeniedHandler(SocketServer.BaseRequestHandler):
+            def handle(self):
+                self.request.close()
+
+        self._mock(MockDeniedHandler)
+
+        c = Client('localhost', port=9998)
+        with self.assertRaises(ClientError):
+            c.connect()
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test.py
+++ b/test.py
@@ -55,8 +55,7 @@ class TestClient(unittest.TestCase):
         self._mock(MockDeniedHandler)
 
         c = Client('localhost', port=9998)
-        with self.assertRaises(ClientError):
-            c.connect()
+        self.assertRaises(ClientError, c.connect)
 
     def test_list(self):
         class MockListHandler(SocketServer.BaseRequestHandler):


### PR DESCRIPTION
This improves support for multigraph plugins:
- support for multigraph plugins in config()
- use same level of nested dicts in multigraph and non-multigraph plugins in fetch() - **this makes fetch() incompatible with existing code**
- announce support for multigraph to munin-node (fixes missing plugins in list())

Also included:
- raise exception if server closed connection unexpectedly (previously methods  just returned an empty string)
- some rudimentary tests
